### PR TITLE
Change ProfileEvents.prefab meta file as guid matches StoreEvents.prefab guid

### DIFF
--- a/Soomla/Assets/Soomla/Prefabs/ProfileEvents.prefab.meta
+++ b/Soomla/Assets/Soomla/Prefabs/ProfileEvents.prefab.meta
@@ -1,4 +1,4 @@
 fileFormatVersion: 2
-guid: 5d99d2a7afd4a4856b8b091c814944c3
+guid: a769c5cf5634d4b9e878d7d59e94d625
 NativeFormatImporter:
   userData: 


### PR DESCRIPTION
A common confusion on the answers forum is when someone installs Store then installs Profile (or vice versa) and the preexisting StoreEvent.prefab or ProfileEvent.prefab has been changed to the other package's prefab.

This is because the guid in the .meta file are the same for both prefabs.  So I changed this .meta file which should stop the prefab getting overwritten.