### PR TITLE
[FIX] Profile plugin - crash in ProfileSettings.cs when editing FB permission in inspector

### DIFF
--- a/Soomla/Assets/Plugins/Soomla/Profile/Config/ProfileSettings.cs
+++ b/Soomla/Assets/Plugins/Soomla/Profile/Config/ProfileSettings.cs
@@ -95,9 +95,7 @@ namespace Soomla.Profile
 		{
 			List<string> savedStates = new List<string>();
 			foreach (var entry in socialIntegrationState) {
-				if (entry.Value != null) {
-					savedStates.Add(entry.Key + "," + (entry.Value.Value ? 1 : 0));
-				}
+				savedStates.Add(entry.Key + "," + ((entry.Value != null && entry.Value.Value) ? 1 : 0));
 			}
 
 			string result = string.Empty;


### PR DESCRIPTION
This fix solves the following issue:
http://answers.soom.la/t/soomla-profile-facebook-permissions-indexoutofrangeexception/2994