### PR TITLE
Feature #187 Make download_deps scripts cache downloaded files in ~/.soomla

### DIFF
--- a/download_deps
+++ b/download_deps
@@ -3,9 +3,16 @@ set -e
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 cd $DIR
 
+UNITY_PROFILE_CACHE=~/.soomla/cache/android-profile
+mkdir -p $UNITY_PROFILE_CACHE
+
+FACEBOOK_SDK_NAME=facebooksdk-7.2.2.zip
 if [ ! -d Soomla/Assets/Facebook ];
 then
-	curl -L -o facebook-sdk.zip http://library.soom.la/fetch/unity3d-profile-facebook/7.2.2?cf=dl_deps
-	unzip -o facebook-sdk.zip -d Soomla
-	rm facebook-sdk.zip
+    if [ ! -f $UNITY_PROFILE_CACHE/$FACEBOOK_SDK_NAME ];
+    then
+        curl -L -o $UNITY_PROFILE_CACHE/$FACEBOOK_SDK_NAME.tmp http://library.soom.la/fetch/unity3d-profile-facebook/7.2.2?cf=dl_deps
+        mv $UNITY_PROFILE_CACHE/$FACEBOOK_SDK_NAME.tmp $UNITY_PROFILE_CACHE/$FACEBOOK_SDK_NAME
+    fi
+	unzip -o $UNITY_PROFILE_CACHE/$FACEBOOK_SDK_NAME -d Soomla
 fi


### PR DESCRIPTION
 + Submodules wasn't updated yet (because it isn't merged)