### PR TITLE
fix issue #95

### DIFF
--- a/soomla-native/projects/unity-android-profile/src/com/soomla/profile/unity/ProfileEventHandler.java
+++ b/soomla-native/projects/unity-android-profile/src/com/soomla/profile/unity/ProfileEventHandler.java
@@ -669,7 +669,7 @@ public class ProfileEventHandler {
         BusProvider.getInstance().post(new GetContactsFinishedEvent(provider, ISocialProvider.SocialActionType.GET_CONTACTS, contacts, payload, hasMore));
     }
 
-    public static void pushEventGetContactsFailed(String providerStr, String message, Boolean fromStart, String payload) {
+    public static void pushEventGetContactsFailed(String providerStr, String message, boolean fromStart, String payload) {
         IProvider.Provider provider = IProvider.Provider.getEnum(providerStr);
         BusProvider.getInstance().post(new GetContactsFailedEvent(provider, ISocialProvider.SocialActionType.GET_CONTACTS, message, fromStart, payload));
     }


### PR DESCRIPTION
Pull request for issue:

I/Unity ( 4767): java.lang.NoSuchMethodError: no static method with name='pushEventGetContactsFailed' signature='(Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)V' in class Lcom/soomla/profile/unity/ProfileEventHandler;
I/Unity ( 4767): at com.unity3d.player.UnityPlayer.nativeRender(Native Method)
I/Unity ( 4767): at com.unity3d.player.UnityPlayer.nativeRender(Native Method)
I/Unity ( 4767): at com.unity3d.player.UnityPlayer.a(Unknown Source)
I/Unity ( 4767): at com.unity3d.player.UnityPlayer$b.run(Unknown Source)
I/Unity ( 4767): at UnityEngine.AndroidJNISafe.CheckException () [0x00000] in :0
I/Unity ( 4767): at UnityEngine.AndroidJNISafe.GetStaticMethodID (IntPtr clazz, System.String name, System.String sig) [0x00000] in :0
I/Unity ( 4767): at UnityEngine._AndroidJNIHelper.GetMethodID (IntPtr jclass, System.String methodName, System.String signature, Boo
